### PR TITLE
Corrige tela branca ao selecionar quantidade no pedido

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,12 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- A tradução automática do navegador substitui TextNodes do DOM e faz o React
+         quebrar com "removeChild: node is not a child of this node" (tela branca). -->
+    <meta name="google" content="notranslate" />
     <title>COMAX</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Erro não tratado capturado pelo ErrorBoundary:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="min-h-screen flex items-center justify-center p-6">
+          <div className="max-w-md text-center space-y-4">
+            <h1 className="text-xl font-semibold text-gray-800">
+              Ocorreu um problema ao carregar esta página
+            </h1>
+            <p className="text-sm text-gray-600">
+              Por favor, atualize a página. Se o problema continuar, entre em contato com o suporte.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Atualizar página
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -115,11 +115,11 @@ export const ProductCard = ({ product, onQuantitySelect, resetItem }: ProductCar
                           <div key={qty} className="flex flex-col items-center gap-1">
                             <RadioGroupItem 
                               value={qty.toString()} 
-                              id={`${size.label}-${qty}`} 
+                              id={`${product.id}-${size.label}-${qty}`}
                               className="md:scale-75 scale-125"
                             />
-                            <Label 
-                              htmlFor={`${size.label}-${qty}`} 
+                            <Label
+                              htmlFor={`${product.id}-${size.label}-${qty}`}
                               className="text-xs"
                             >
                               {qty}

--- a/src/components/index/CompanyInfo.tsx
+++ b/src/components/index/CompanyInfo.tsx
@@ -76,7 +76,7 @@ export const CompanyInfo = ({
                               <span>Calculando...</span>
                             </div>
                           ) : (
-                            formattedTotal
+                            <span>{formattedTotal}</span>
                           )}
                         </div>
                       </div>

--- a/src/components/index/OrderForm.tsx
+++ b/src/components/index/OrderForm.tsx
@@ -65,10 +65,10 @@ const SelectQuantityProductList = ({ products, onQuantitySelect, resetItem, isLo
           name: product.name,
           image: product.image || "",
           ref: product.reference,
-          sizes: product.sizes.map(size => ({
+          sizes: (product.sizes || []).map(size => ({
             label: size.size,
             price: size.value,
-            quantities: product.quantities.map(q => q.value)
+            quantities: (product.quantities || []).map(q => q.value)
           })),
           isNew: product.isNew,
           outOfStock: product.outOfStock

--- a/src/components/order/ProductList.tsx
+++ b/src/components/order/ProductList.tsx
@@ -52,10 +52,10 @@ export const ProductList = ({ products, onQuantitySelect, resetItem, isLoading =
           name: product.name,
           image: product.image || "",
           ref: product.reference,
-          sizes: product.sizes.map(size => ({
+          sizes: (product.sizes || []).map(size => ({
             label: size.size,
             price: size.value,
-            quantities: product.quantities.map(q => q.value)
+            quantities: (product.quantities || []).map(q => q.value)
           })),
           outOfStock: product.outOfStock
         };

--- a/src/components/order/ProductSelectionCard.tsx
+++ b/src/components/order/ProductSelectionCard.tsx
@@ -96,11 +96,11 @@ export const ProductSelectionCard = ({ product, onQuantitySelect, resetItem }: P
                     <div key={qty} className="flex items-center gap-1">
                       <RadioGroupItem 
                         value={qty.toString()} 
-                        id={`${size.label}-${qty}-compact`}
+                        id={`${product.id}-${size.label}-${qty}-compact`}
                         className="scale-75"
                       />
-                      <Label 
-                        htmlFor={`${size.label}-${qty}-compact`} 
+                      <Label
+                        htmlFor={`${product.id}-${size.label}-${qty}-compact`}
                         className="text-xs"
                       >
                         {qty}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
+import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import './index.css'
 
 const queryClient = new QueryClient({
@@ -14,7 +15,9 @@ const queryClient = new QueryClient({
 })
 
 createRoot(document.getElementById("root")!).render(
-  <QueryClientProvider client={queryClient}>
-    <App />
-  </QueryClientProvider>
+  <ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </ErrorBoundary>
 );

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -21,8 +21,8 @@ export const fetchProducts = async (companyId: string): Promise<Product[]> => {
     reference: product.reference,
     name: product.name,
     image: product.image_url,
-    sizes: (product.sizes as Array<{size: string; value: number}>),
-    quantities: Array.isArray(product.quantities) 
+    sizes: Array.isArray(product.sizes) ? (product.sizes as Array<{size: string; value: number}>) : [],
+    quantities: Array.isArray(product.quantities)
       ? product.quantities.map(q => typeof q === 'number' ? { value: q } : q)
       : [],
     disabled: product.disabled,


### PR DESCRIPTION
## Problema

Clientes relataram que, ao selecionar as quantidades no pedido, a tela ficava toda branca e não era possível finalizar. O problema não reproduzia em testes internos.

Reproduzido em celular Android **com a tradução do navegador ativada**.

## Causa raiz

A tradução automática do navegador substitui os TextNodes do DOM pelos textos traduzidos. Quando o React depois tenta remover um nó que o tradutor já trocou, o navegador lança `NotFoundError: Failed to execute 'removeChild' on 'Node'` — um erro fatal que derruba a árvore de componentes inteira, resultando em tela branca.

Três fatores se combinavam:

1. **`<html lang="en">`** — a aplicação é toda em português, mas se declarava como inglês. O Chrome no Android detecta a divergência e oferece/aplica a tradução automaticamente. Isso explica por que só algumas clientes eram afetadas: depende da configuração de idioma de cada aparelho.

2. **O gatilho era a seleção de quantidade.** Em `CompanyInfo.tsx`, o bloco do total (`{total > 0 && ...}`) só entra no DOM quando a primeira quantidade é selecionada — exatamente a ação relatada. Esse bloco contém textos condicionais em ternários, o padrão mais propenso a esse crash.

Referências: [radix-ui/primitives#2578](https://github.com/radix-ui/primitives/issues/2578), [facebook/react#26048](https://github.com/facebook/react/issues/26048), [artigo técnico](https://martijnhols.nl/blog/everything-about-google-translate-crashing-react).

## Mudanças

- **`index.html`**: `lang="pt-BR"`, `translate="no"` e `<meta name="google" content="notranslate">` — elimina a causa raiz impedindo a tradução automática.
- **`CompanyInfo.tsx`**: texto condicional do total envolvido em `<span>`, reduzindo a exposição ao padrão de crash.
- **`ErrorBoundary.tsx`** (novo) + **`main.tsx`**: ErrorBoundary global. Não impede este crash específico, mas garante que qualquer erro de renderização futuro exiba uma mensagem com opção de recarregar, em vez de tela branca.

### Correção adicional (bug separado, encontrado na investigação)

- **`ProductCard.tsx`** e **`ProductSelectionCard.tsx`**: os IDs dos radios de quantidade eram montados como `${size.label}-${qty}`, sem o id do produto. Como vários produtos compartilham os mesmos tamanhos e quantidades, isso gerava IDs duplicados no DOM — clicar no label podia marcar a quantidade de **outro produto**. Validado em produção: uma loja renderizava 1124 radios; após a correção, zero IDs duplicados.

- **`productService.ts`**, **`ProductList.tsx`**, **`OrderForm.tsx`**: tratamento defensivo para `sizes`/`quantities` nulos. Não era a causa do bug (uma varredura nos 150 produtos da base não encontrou inconsistências em produtos ativos), mas evita uma classe inteira de falhas de renderização.

## Verificação

- `tsc --noEmit` sem erros
- `npm run build` sem erros
- ErrorBoundary validado capturando um erro real de renderização
- Ausência de IDs duplicados validada contra dados de produção

## Observação

Se futuramente for necessário permitir a tradução da loja pública, o `notranslate` terá de sair — e aí os textos condicionais precisarão ser tratados um a um. Pontos de risco remanescentes: `OrderSummaryTable.tsx`, `ProductSelectQuantityCard.tsx`, `ProductCard.tsx`, `OrderSummaryButton.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)